### PR TITLE
Plain JSON keys instead of tree keys

### DIFF
--- a/src/main/java/com/jvms/i18neditor/editor/Editor.java
+++ b/src/main/java/com/jvms/i18neditor/editor/Editor.java
@@ -209,7 +209,7 @@ public class Editor extends JFrame {
 		if (project != null) {
 			for (Resource resource : project.getResources()) {
 				try {
-					Resources.write(resource, !project.isMinifyResources());
+					Resources.write(resource, !project.isMinifyResources(), project.isPlainJSON());
 				} catch (IOException e) {
 					error = true;
 					log.error("Error saving resource file " + resource.getPath(), e);
@@ -831,6 +831,7 @@ public class Editor extends JFrame {
 	private void storeProjectState() {
 		ExtendedProperties props = new ExtendedProperties();
 		props.setProperty("minify_resources", project.isMinifyResources());
+		props.setProperty("plain_json", project.isPlainJSON());
 		props.setProperty("resource_name", project.getResourceName());
 		props.setProperty("resource_type", project.getResourceType().toString());
 		props.store(Paths.get(project.getPath().toString(), PROJECT_FILE));
@@ -842,6 +843,7 @@ public class Editor extends JFrame {
 		if (Files.exists(path)) {
 			props.load(Paths.get(project.getPath().toString(), PROJECT_FILE));
 			project.setMinifyResources(props.getBooleanProperty("minify_resources", settings.isMinifyResources()));
+			project.setPlainJSON(props.getBooleanProperty("plain_json", settings.isPlainJSON()));
 			project.setResourceName(props.getProperty("resource_name", settings.getResourceName()));
 			project.setResourceType(props.getEnumProperty("resource_type", ResourceType.class));
 		} else {
@@ -858,6 +860,7 @@ public class Editor extends JFrame {
 		props.setProperty("window_pos_y", getY());
 		props.setProperty("window_div_pos", contentPane.getDividerLocation());
 		props.setProperty("minify_resources", settings.isMinifyResources());
+		props.setProperty("plain_json", settings.isPlainJSON());
 		props.setProperty("resource_name", settings.getResourceName());
 		props.setProperty("check_version", settings.isCheckVersionOnStartup());
 		props.setProperty("default_input_height", settings.getDefaultInputHeight());
@@ -891,6 +894,7 @@ public class Editor extends JFrame {
 		settings.setLastExpandedNodes(props.getListProperty("last_expanded"));
 		settings.setLastSelectedNode(props.getProperty("last_selected"));
 		settings.setMinifyResources(props.getBooleanProperty("minify_resources", false));
+		settings.setPlainJSON(props.getBooleanProperty("plain_json", false));
 		settings.setResourceName(props.getProperty("resource_name", DEFAULT_RESOURCE_NAME));
 		settings.setCheckVersionOnStartup(props.getBooleanProperty("check_version", true));
 		settings.setDefaultInputHeight(props.getIntegerProperty("default_input_height", 5));

--- a/src/main/java/com/jvms/i18neditor/editor/EditorProject.java
+++ b/src/main/java/com/jvms/i18neditor/editor/EditorProject.java
@@ -19,6 +19,7 @@ public class EditorProject {
 	private ResourceType resourceType;
 	private List<Resource> resources = Lists.newLinkedList();
 	private boolean minifyResources;
+	private boolean plainJSON;
 	
 	public EditorProject(Path path) {
 		this.path = path;
@@ -70,5 +71,13 @@ public class EditorProject {
 
 	public void setMinifyResources(boolean minifyResources) {
 		this.minifyResources = minifyResources;
+	}
+
+	public boolean isPlainJSON() {
+		return plainJSON;
+	}
+
+	public void setPlainJSON(boolean plainJSON) {
+		this.plainJSON = plainJSON;
 	}
 }

--- a/src/main/java/com/jvms/i18neditor/editor/EditorProjectSettingsPane.java
+++ b/src/main/java/com/jvms/i18neditor/editor/EditorProjectSettingsPane.java
@@ -41,7 +41,12 @@ public class EditorProjectSettingsPane extends AbstractSettingsPane {
 			minifyBox.addChangeListener(e -> project.setMinifyResources(minifyBox.isSelected()));
 			fieldset1.add(minifyBox, createVerticalGridBagConstraints());
 		}
-		
+		if (project.getResourceType().equals(ResourceType.JSON)) {
+			JCheckBox plainJSONBox = new JCheckBox(MessageBundle.get("settings.plainJSON.title"));
+			plainJSONBox.setSelected(project.isPlainJSON());
+			plainJSONBox.addChangeListener(e -> project.setPlainJSON(plainJSONBox.isSelected()));
+			fieldset1.add(plainJSONBox, createVerticalGridBagConstraints());
+		}
 		JPanel resourcePanel = new JPanel(new GridLayout(0, 1));
 		JLabel resourceNameLabel = new JLabel(MessageBundle.get("settings.resourcename.title"));
 		JTextField resourceNameField = new JTextField(project.getResourceName());

--- a/src/main/java/com/jvms/i18neditor/editor/EditorSettings.java
+++ b/src/main/java/com/jvms/i18neditor/editor/EditorSettings.java
@@ -15,6 +15,7 @@ public class EditorSettings {
 	private int windowHeight;
 	private String resourceName;
 	private boolean minifyResources;
+	private boolean plainJSON;
 	private List<String> history;
 	private List<String> lastExpandedNodes;
 	private String lastSelectedNode;
@@ -133,5 +134,13 @@ public class EditorSettings {
 
 	public void setDoubleClickTreeToggling(boolean doubleClickTreeToggling) {
 		this.doubleClickTreeToggling = doubleClickTreeToggling;
+	}
+
+	public boolean isPlainJSON() {
+		return plainJSON;
+	}
+
+	public void setPlainJSON(boolean plainJSON) {
+		this.plainJSON = plainJSON;
 	}
 }

--- a/src/main/resources/bundles/messages.properties
+++ b/src/main/resources/bundles/messages.properties
@@ -91,7 +91,7 @@ settings.minify.title = Minify translations on save
 settings.resourcename.title = Translations filename
 settings.treetogglemode.title = Expand and collapse translations using double click
 settings.checkversion.title = Check for new version on startup
-
+settings.plainJSON.title= Plain JSON keys
 swing.action.copy = Copy
 swing.action.cut = Cut
 swing.action.delete = Delete

--- a/src/main/resources/bundles/messages_nl.properties
+++ b/src/main/resources/bundles/messages_nl.properties
@@ -91,6 +91,7 @@ settings.minify.title = Comprimeer vertalingen bij opslaan
 settings.resourcename.title = Bestandsnaam vertalingen
 settings.treetogglemode.title = Vertalingen in- en uitvouwen met dubbelklik
 settings.checkversion.title = Controleer op nieuwe versie bij opstarten
+settings.plainJSON.title= Plain JSON keys
 
 swing.action.copy = Kopi\u00ebren
 swing.action.cut = Knippen

--- a/src/main/resources/bundles/messages_pt_BR.properties
+++ b/src/main/resources/bundles/messages_pt_BR.properties
@@ -91,6 +91,7 @@ settings.minify.title = Minificar tradu\u00e7\u00f5es ao salvar
 settings.resourcename.title = Nome do arquivo de tradu\u00e7\u00e3es
 settings.treetogglemode.title = Expandir e contrair tradu\u00e7\u00f5es usando duplo clique
 settings.checkversion.title = Verificar a nova vers\u00e3o na inicializa\u00e7\u00e3o
+settings.plainJSON.title= Plain JSON keys
 
 swing.action.copy = Copiar
 swing.action.cut = Cortar


### PR DESCRIPTION
Hi,
I finally implemented the Plain JSON keys options.
Now the i18n editor is compatible with react-int translations files.
(https://github.com/yahoo/react-intl)
This is the issue:
https://github.com/jcbvm/i18n-editor/issues/41

Best regards.