### PR TITLE
Launch4j version updated build to run on ubuntu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 			<plugin>
 				<groupId>com.akathist.maven.plugins.launch4j</groupId>
 				<artifactId>launch4j-maven-plugin</artifactId>
-				<version>1.7.7</version>
+				<version>1.7.25</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -121,7 +121,7 @@
 			      		</goals>
 			      		<configuration>
 			        		<target>
-			          			<copy file="${project.build.directory}/${project.artifactId}-${project.version}-jar-with-dependencies.jar" 
+			          			<copy file="${project.build.directory}/${project.artifactId}-${project.version}-jar-with-dependencies.jar"
 			          				  toFile="${project.build.directory}/${project.artifactId}-${project.version}/${project.artifactId}.jar"/>
 			        		</target>
 			      		</configuration>


### PR DESCRIPTION
Hi,
mvn clean package doesn't work on ubuntu, error:

[ERROR] Failed to execute goal com.akathist.maven.plugins.launch4j:launch4j-maven-plugin:1.7.7:launch4j (default) on project i18n-editor: Failed to build the executable; please verify your configuration.: net.sf.launch4j.ExecException: java.io.IOException: Cannot run program "/home/david/.m2/repository/net/sf/launch4j/launch4j/3.8.0/launch4j-3.8.0-workdir-linux/bin/windres": error=2, No such file or directory -> [Help 1]

But the file is actually present.

As first approach i just upgraded the version of launch4j on my pom.xml and the error disappeared and at least now i'm able to build the jar file.