### PR TITLE
Fix for locales with '-' separator

### DIFF
--- a/src/main/java/com/jvms/i18neditor/editor/Editor.java
+++ b/src/main/java/com/jvms/i18neditor/editor/Editor.java
@@ -52,6 +52,7 @@ import javax.swing.plaf.basic.BasicSplitPaneDivider;
 import javax.swing.plaf.basic.BasicSplitPaneUI;
 import javax.swing.tree.TreePath;
 
+import com.jvms.i18neditor.util.*;
 import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,15 +68,7 @@ import com.jvms.i18neditor.io.ChecksumException;
 import com.jvms.i18neditor.swing.JFileDrop;
 import com.jvms.i18neditor.swing.JScrollablePanel;
 import com.jvms.i18neditor.swing.util.Dialogs;
-import com.jvms.i18neditor.util.Colors;
-import com.jvms.i18neditor.util.ExtendedProperties;
-import com.jvms.i18neditor.util.GithubRepoUtil;
 import com.jvms.i18neditor.util.GithubRepoUtil.GithubRepoReleaseData;
-import com.jvms.i18neditor.util.Images;
-import com.jvms.i18neditor.util.Locales;
-import com.jvms.i18neditor.util.MessageBundle;
-import com.jvms.i18neditor.util.ResourceKeys;
-import com.jvms.i18neditor.util.Resources;
 
 /**
  * This class represents the main class of the editor.
@@ -143,8 +136,12 @@ public class Editor extends JFrame {
 			project.setResourceType(type);
 			
 			if (project.getResourceFileStructure() == FileStructure.Flat) {
-				Resource resource = Resources.create(type, dir, 
-						project.getResourceFileDefinition(), FileStructure.Flat, Optional.empty());
+				Resource resource;
+				try {
+					resource = Resources.create(type, dir, project.getResourceFileDefinition(), FileStructure.Flat, null);
+				} catch (LocaleException e) {
+					return;
+				}
 				setupResource(resource);
 				project.addResource(resource);
 			}
@@ -276,17 +273,19 @@ public class Editor extends JFrame {
 			showError(MessageBundle.get("dialogs.locale.add.error.invalid"));
 			return false;
 		}
+		Resource resource;
 		try {
-			Resource resource = Resources.create(project.getResourceType(), project.getPath(), 
-					project.getResourceFileDefinition(), project.getResourceFileStructure(), Optional.of(locale));
-			addResource(resource);
-			requestFocusInFirstResourceField();
-			return true;
-		} catch (IOException e) {
+			resource = Resources.create(project.getResourceType(), project.getPath(),
+					project.getResourceFileDefinition(), project.getResourceFileStructure(), localeString);
+		}
+		catch(LocaleException | IOException e) {
 			log.error("Error creating new locale", e);
 			showError(MessageBundle.get("dialogs.locale.add.error.create"));
 			return false;
 		}
+		addResource(resource);
+		requestFocusInFirstResourceField();
+		return true;
 	}
 	
 	public boolean addTranslation(String key) {

--- a/src/main/java/com/jvms/i18neditor/util/LocaleException.java
+++ b/src/main/java/com/jvms/i18neditor/util/LocaleException.java
@@ -1,0 +1,8 @@
+package com.jvms.i18neditor.util;
+
+public class LocaleException extends Exception {
+
+    public LocaleException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jvms/i18neditor/util/Resources.java
+++ b/src/main/java/com/jvms/i18neditor/util/Resources.java
@@ -193,19 +193,23 @@ public final class Resources {
 	 * @param 	root the root directory to write the resource to.
 	 * @param	filenameDefinition the filename definition of the resource.
 	 * @param	structure the file structure to use
-	 * @param	locale the locale of the resource (optional).
+	 * @param	localeString the locale of the resource (may be null).
 	 * @return	The newly created resource.
 	 * @throws 	IOException if an I/O error occurs writing the file.
 	 */
-	public static Resource create(ResourceType type, Path root, String fileDefinition, FileStructure structure, Optional<Locale> locale) 
-			throws IOException {
+	public static Resource create(ResourceType type, Path root, String fileDefinition, FileStructure structure, String localeString)
+			throws IOException, LocaleException {
+		Locale locale = Locales.parseLocale(localeString);
 		Path path;
 		if (structure == FileStructure.Nested) {
-			path = Paths.get(root.toString(), locale.get().toString(), getFilename(fileDefinition, locale) + type.getExtension());
+			if (locale == null) {
+				throw new LocaleException(String.format("Unknown locale specified: %s.", localeString));
+			}
+			path = Paths.get(root.toString(), localeString, getFilename(fileDefinition, Optional.of(locale)) + type.getExtension());
 		} else {
-			path = Paths.get(root.toString(), getFilename(fileDefinition, locale) + type.getExtension());
+			path = Paths.get(root.toString(), getFilename(fileDefinition, Optional.empty()) + type.getExtension());
 		}
-		Resource resource = new Resource(type, path, locale.orElse(null));
+		Resource resource = new Resource(type, path, locale);
 		write(resource, false, false);
 		return resource;
 	}


### PR DESCRIPTION
The program didn't work well if locale was defined using '-' as separator character between language and region.