### PR TITLE
Quickly find the previous/next error in the translation tree

### DIFF
--- a/src/main/java/com/jvms/i18neditor/editor/EditorMenuBar.java
+++ b/src/main/java/com/jvms/i18neditor/editor/EditorMenuBar.java
@@ -24,6 +24,8 @@ import com.jvms.i18neditor.editor.menu.CopyTranslationKeyToClipboardMenuItem;
 import com.jvms.i18neditor.editor.menu.DuplicateTranslationMenuItem;
 import com.jvms.i18neditor.editor.menu.ExpandTranslationsMenuItem;
 import com.jvms.i18neditor.editor.menu.FindTranslationMenuItem;
+import com.jvms.i18neditor.editor.menu.NextTranslationErrorMenuItem;
+import com.jvms.i18neditor.editor.menu.PreviousTranslationErrorMenuItem;
 import com.jvms.i18neditor.editor.menu.RemoveTranslationMenuItem;
 import com.jvms.i18neditor.editor.menu.RenameTranslationMenuItem;
 import com.jvms.i18neditor.swing.util.Dialogs;
@@ -195,6 +197,9 @@ public class EditorMenuBar extends JMenuBar {
         viewMenu.setMnemonic(MessageBundle.getMnemonic("menu.view.vk"));
         viewMenu.add(new ExpandTranslationsMenuItem(tree));
         viewMenu.add(new CollapseTranslationsMenuItem(tree));
+        viewMenu.addSeparator();
+        viewMenu.add(new PreviousTranslationErrorMenuItem(tree));
+        viewMenu.add(new NextTranslationErrorMenuItem(tree));
         
         // Settings menu
         settingsMenu = new JMenu(MessageBundle.get("menu.settings.title"));

--- a/src/main/java/com/jvms/i18neditor/editor/TranslationTree.java
+++ b/src/main/java/com/jvms/i18neditor/editor/TranslationTree.java
@@ -47,6 +47,32 @@ public class TranslationTree extends JTree {
 		}
 	}
 	
+	public void gotoPreviousError() {
+		TranslationTreeNode node = getSelectionNode();
+		do {
+			node = (TranslationTreeNode)node.getPreviousNode();
+			if (node != null) {
+				if (node.hasError()) {
+					setSelectionNode(node);
+					break;
+				}
+			}
+		} while (node != null);
+	}
+	
+	public void gotoNextError() {
+		TranslationTreeNode node = getSelectionNode();
+		do {
+			node = (TranslationTreeNode)node.getNextNode();
+			if (node != null) {
+				if (node.hasError()) {
+					setSelectionNode(node);
+					break;
+				}
+			}
+		} while (node != null);		
+	}
+	
 	public void expand(List<TranslationTreeNode> nodes) {
 		nodes.forEach(n -> expandPath(new TreePath(n.getPath())));
 	}

--- a/src/main/java/com/jvms/i18neditor/editor/menu/NextTranslationErrorMenuItem.java
+++ b/src/main/java/com/jvms/i18neditor/editor/menu/NextTranslationErrorMenuItem.java
@@ -1,0 +1,25 @@
+package com.jvms.i18neditor.editor.menu;
+
+import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
+
+import javax.swing.JMenuItem;
+import javax.swing.KeyStroke;
+
+import com.jvms.i18neditor.editor.TranslationTree;
+import com.jvms.i18neditor.util.MessageBundle;
+
+/**
+ * This class represents a menu item to navigate to the next translation error in the translation tree.
+ * 
+ * @author Frédéric Courchesne
+ */
+public class NextTranslationErrorMenuItem extends JMenuItem {
+	//private final static long serialVersionUID = 7316102121075733726L;
+
+	public NextTranslationErrorMenuItem(TranslationTree tree) {
+        super(MessageBundle.get("menu.view.nexterror.title"));
+        setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+     	addActionListener(e -> tree.gotoNextError());
+	}
+}

--- a/src/main/java/com/jvms/i18neditor/editor/menu/PreviousTranslationErrorMenuItem.java
+++ b/src/main/java/com/jvms/i18neditor/editor/menu/PreviousTranslationErrorMenuItem.java
@@ -1,0 +1,25 @@
+package com.jvms.i18neditor.editor.menu;
+
+import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
+
+import javax.swing.JMenuItem;
+import javax.swing.KeyStroke;
+
+import com.jvms.i18neditor.editor.TranslationTree;
+import com.jvms.i18neditor.util.MessageBundle;
+
+/**
+ * This class represents a menu item to navigate to the previous translation error in the translation tree.
+ * 
+ * @author Frédéric Courchesne
+ */
+public class PreviousTranslationErrorMenuItem extends JMenuItem {
+	//private final static long serialVersionUID = 7316102121075733726L;
+
+	public PreviousTranslationErrorMenuItem(TranslationTree tree) {
+        super(MessageBundle.get("menu.view.previouserror.title"));
+        setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+     	addActionListener(e -> tree.gotoPreviousError());
+	}
+}


### PR DESCRIPTION
This pull request adds two new menu items in the "View" menu to navigate to errors in the translation tree. Each menu item is bound to a new keyboard shortcut.

![image](https://user-images.githubusercontent.com/15271147/81615996-acbfce80-93b0-11ea-9379-f61b9c0d1c83.png)

Labels are not localized in this pull request (english only).